### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/abhishekpanda0620/eol-check/security/code-scanning/2](https://github.com/abhishekpanda0620/eol-check/security/code-scanning/2)

To address this issue, add a `permissions` block with the least privileges necessary for this workflow. In CI jobs that do not require write access (e.g., testing, linting, building), `contents: read` is sufficient. This should be added either at the root level of the workflow (to apply to all jobs) or specifically under the `test` job in the workflow file, but best practice is to place it at the workflow level unless other jobs will require broader permissions. Edit `.github/workflows/ci.yml` by adding:
```yaml
permissions:
  contents: read
```
immediately underneath the workflow `name:` (preferably between lines 1 and 2) so all jobs inherit this restriction. No additional packages, imports, or method changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
